### PR TITLE
Add option "--color" to control colorization & Fix UnicodeEncodeError in python2.

### DIFF
--- a/ydcv.py
+++ b/ydcv.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from argparse import ArgumentParser
 import json
 import re
+import sys
 
 try:
     #Py3
@@ -13,6 +14,8 @@ except ImportError:
     #Py 2.7
     from urllib import quote
     from urllib2 import urlopen
+    reload(sys)
+    sys.setdefaultencoding('utf8')
 
 
 API = "YouDaoCV"
@@ -52,6 +55,10 @@ class Colorizing(object):
 
     @classmethod
     def colorize(cls, s, color=None):
+        if options.color == 'never':
+            return s
+        if options.color == 'auto' and not sys.stdout.isatty():
+            return s
         if color in cls.colors:
             return "{0}{1}{2}".format(
                 cls.colors[color], s, cls.colors['default'])
@@ -138,6 +145,11 @@ if __name__ == "__main__":
                         default=False,
                         help="only show explainations. "
                             "argument \"-f\" will not take effect")
+    parser.add_argument('--color',
+                        choices=['always', 'auto', 'never'],
+                        default='auto',
+                        help="colorize the output. "
+                             "Default to 'auto' or can be 'never' or 'always'.")
     parser.add_argument('words', nargs='+', help=
                         "words to lookup, or quoted sentences to translate.")
 


### PR DESCRIPTION
Now you can indicate WHEN ydcv colorize the output by setting --color=WHEN.
With --color=auto (default), just like `ls` or `grep`, ydcv emits color code only when standard output is connected to a teriminal. So it avoids certain problems when its output is redirected or is fed to pipe as well as programs such as emacs.
Other available WHEN is 'never' and 'always'.

This commit also fix a bug that redirect the ouput can cause a UnicodeEncodeError in python2 environment.
