### PR TITLE
Proposal:  Provide Z Shell completion script for ydcv

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,7 @@
+Here is a brief description of the files included in this directory:
+---
+
+- [zsh_completion][1] - a Z Shell completion script, install (with a rename) to
+`/usr/share/zsh/site-functions/`.
+
+[1]: https://github.com/felixonmars/ydcv/blob/master/contrib/zsh_completion

--- a/contrib/zsh_completion
+++ b/contrib/zsh_completion
@@ -1,0 +1,39 @@
+#compdef ydcv
+# --------------------------------------------------------------------
+# Description
+# --------------------------------------------------------------------
+#
+# Completion script for ydcv (https://github.com/felixonmars/ydcv)
+#
+# --------------------------------------------------------------------
+# Authors
+# --------------------------------------------------------------------
+#
+# Fernando "Firef0x" G.P. da Silva <firefgx { aT ) gmail [ d0t } com>
+#
+# --------------------------------------------------------------------
+# Install
+# --------------------------------------------------------------------
+#
+# Copy this file to /usr/share/zsh/site-functions/_ydcv
+#
+# --------------------------------------------------------------------
+
+# options for passing to _arguments: main ydcv commands
+ydcv_opts_commands=(
+    '(-f --full)'{-f,--full}'[print full web reference, only the first 3 results will be printed without this flag.]'
+    '(-h --help)'{-h,--help}'[show this help message and exit]'
+    '--color[colorize the output. Default to "auto" or can be "never" or "always".]'
+    '(-s --simple)'{-s,--simple}'[only show explainations. argument "-f" will not take effect]'
+    '(-x --selection)'{-x,--selection}'[show explaination of current selection.]'
+)
+
+case "${words[CURRENT - 1]}" in
+	"--color")
+		coloropts=(auto always never)
+		compadd $coloropts
+		;;
+	*)
+		_arguments $ydcv_opts_commands
+		;;
+esac


### PR DESCRIPTION
@felixonmars 大神，您好！

很抱歉我修改过后忘了推送上来了。这份拉取请求为 `ydcv` 提供 `Z Shell` 自动补全文件，部分解决 https://github.com/felixonmars/ydcv/issues/21 中提出的问题。即：

- [x] 列出所有参数项

```
  -h, --help            show this help message and exit
  -f, --full            print full web reference, only the first 3 results
                        will be printed without this flag.
  -s, --simple          only show explainations. argument "-f" will not take
                        effect
  -x, --selection       show explaination of current selection.
  --color {always,auto,never}
                        colorize the output. Default to 'auto' or can be
                        'never' or 'always'.
```

![ydcv1](https://cloud.githubusercontent.com/assets/2487841/6650613/17a27efa-ca58-11e4-8960-aad3928c3809.png)

- [x] 列出 `--color` 的所有可选参数

![ydcv2](https://cloud.githubusercontent.com/assets/2487841/6650614/17b898de-ca58-11e4-8d19-40b2a47c74d0.png)

另外我修改了一下软件包 [ydcv-git](https://aur.archlinux.org/packages/ydcv-git/) 的 `PKGBUILD`，以供您及大家测试。
`PKGBUILD` 见 https://gist.github.com/Firef0x/162516f4d1f865cbd5ca ；
二进制包见 https://github.com/Firef0x/ydcv/releases/download/0.3.6.20150307.cd10332/ydcv-git-0.3.6.20150307.cd10332-1-any.pkg.tar 。

期待大神的审阅及意见。

此致！