### PR TITLE
add setup.py and just one more step to upload it to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+
+build
+dist
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+with open('README.md') as f:
+    long_description = f.read().strip()
+
+
+setup(
+    name="ydcv",
+    version="0.0.1",
+    description="YouDao Console Version, a simple wrapper for Youdao API",
+    long_description=long_description,
+    # classifiers=[],
+    # keywords="",
+    author="Felix Yan",
+    author_email="felixonmars@archlinux.org",
+    url="https://github.com/felixonmars/ydcv",
+    # license="",
+    package_dir={'': 'src'},
+    py_modules=['ydcv'],
+    entry_points={
+        'console_scripts': ['ydcv=ydcv:main'],
+    },
+)

--- a/src/ydcv.py
+++ b/src/ydcv.py
@@ -28,6 +28,22 @@ API = "YouDaoCV"
 API_KEY = "659600698"
 
 
+class GlobalOptions(object):
+    def __init__(self, options=None):
+        self._options = options
+
+    def __getattr__(self, name):
+        if name in dir(GlobalOptions) or name in self.__dict__:
+            return getattr(self, name)
+        elif name in self._options.__dict__:
+            return getattr(self._options, name)
+        else:
+            raise AttributeError("'%s' has no attribute '%s'" % (
+                self.__class__.__name__, name))
+
+options = GlobalOptions()
+
+
 class Colorizing(object):
     colors = {
         'none': "",
@@ -181,7 +197,7 @@ def lookup_word(word):
         print_explanation(json.loads(data), options)
 
 
-if __name__ == "__main__":
+def arg_parse():
     parser = ArgumentParser(description="Youdao Console Version")
     parser.add_argument('-f', '--full',
                         action="store_true",
@@ -213,8 +229,11 @@ if __name__ == "__main__":
     parser.add_argument('words',
                         nargs='*',
                         help="words to lookup, or quoted sentences to translate.")
+    return parser.parse_args()
 
-    options = parser.parse_args()
+
+def main():
+    options._options = arg_parse()
 
     if options.words:
         for word in options.words:
@@ -253,3 +272,6 @@ if __name__ == "__main__":
                 except EOFError:
                     break
         print("\nBye")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi, Felix,

I just migrated from arch to gentoo recently. A little bit surprise that I found this wonderful tool hasn't been uploaded to pypi. I noticed that #26 has already been labeled `enhancement`. So I just added `setup.py` and made some changes to the code so that it can be installed as a script command. After `python setup.py install`, it works in my virtualenv environment.

To upload it to pypi, it should be as easy as typing `python setup.py upload`. But you have to create a account first. And I cannot decide some information by myself like `license`, `keywords`, `classifier`. I just leave them commended out in the `setup.py`

If you do not have time, I would be very pleased to upload it to my account. But last time when I uploaded my own package, I have problem in searching it. But I can install them without trouble if I know the name of it. I guess it's because the displaying weight of my account is too low.

BTW, there are only two packages in the PyPI2 providing cmdline wrapper to youdao API --  `youdao` and `YoudaoDict`. But `YoudaoDict` lacks coloring and `youdao` has too much dependencies. I think this tool will be very competitive in the Python Package Index.
