### PR TITLE
Change CLI name to yd for simplicity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={'': 'src'},
     py_modules=['ydcv'],
     entry_points={
-        'console_scripts': ['ydcv=ydcv:main'],
+        'console_scripts': ['yd=ydcv:main'],
     },
     setup_requires=setup_requires,
     use_scm_version=True,


### PR DESCRIPTION
pip3 install ydcv安装后，我马上加了alias yd=ydcv，命令行改成yd应该更简洁，希望考虑一下。