### PR TITLE
Specify source file encoding

### DIFF
--- a/src/ydcv.py
+++ b/src/ydcv.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=UTF-8
 from __future__ import unicode_literals
 from __future__ import print_function
 from argparse import ArgumentParser


### PR DESCRIPTION
This one-line pull request fixes bug https://github.com/felixonmars/ydcv/issues/46 on Python 2. It specifies in the encoding in the source file, as is mandated by PEP 263 (https://www.python.org/dev/peps/pep-0263/)